### PR TITLE
Fix navbar z-index

### DIFF
--- a/src/public/styles/layouts/_nav.scss
+++ b/src/public/styles/layouts/_nav.scss
@@ -2,6 +2,7 @@
     /*Columa contenedora de la barra de navegación*/
     width: 200px;
     height: 100vh;
+    z-index: 100;
     background-color: $very_dark;
     
     /*Display flex para poner el logo encima de las opciones de navegación*/

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -936,8 +936,9 @@ main {
 
 /*Clase para fijar el body cuando se abre el menú en mobile*/
 .body--fixed {
-  top: 68px;
+  top: 70px;
   /*Valor calculado a partir de los márgenes y padding existentes*/
+  width: 100%;
   position: fixed;
 }
 

--- a/src/public/styles/main.css
+++ b/src/public/styles/main.css
@@ -433,6 +433,7 @@ label {
   /*Columa contenedora de la barra de navegación*/
   width: 200px;
   height: 100vh;
+  z-index: 100;
   background-color: #0d141c;
   /*Display flex para poner el logo encima de las opciones de navegación*/
   display: -webkit-box;
@@ -935,8 +936,9 @@ main {
 
 /*Clase para fijar el body cuando se abre el menú en mobile*/
 .body--fixed {
-  position: -webkit-sticky;
-  position: sticky;
+  top: 68px;
+  /*Valor calculado a partir de los márgenes y padding existentes*/
+  position: fixed;
 }
 
 /*PARA CELULARES*/

--- a/src/public/styles/main.scss
+++ b/src/public/styles/main.scss
@@ -50,7 +50,8 @@ main{
 
 /*Clase para fijar el body cuando se abre el menú en mobile*/
 .body--fixed{
-    position: sticky; 
+    top: 68px; /*Valor calculado a partir de los márgenes y padding existentes*/
+    position: fixed; 
 }
 
 @import './mediaQueries'; 

--- a/src/public/styles/main.scss
+++ b/src/public/styles/main.scss
@@ -50,7 +50,8 @@ main{
 
 /*Clase para fijar el body cuando se abre el menú en mobile*/
 .body--fixed{
-    top: 68px; /*Valor calculado a partir de los márgenes y padding existentes*/
+    top: 70px; /*Valor calculado a partir de los márgenes y padding existentes*/
+    width: 100%;
     position: fixed; 
 }
 


### PR DESCRIPTION
# CORRECCIÓN DE ERROR EN LA BARRA DE NAVEGACIÓN 🐛

## DESCRIPCIÓN

Se arregló un problema de la barra de navegación detectado por @diegoaach .

El problema consistía en que los elementos del la página se ponían sobre la barra de navegación en celulares. 

## CAPTURAS DE PANTALLA

Problema que se solucionó: 

![image](https://user-images.githubusercontent.com/62714297/158074194-bf8fad68-9c81-4bfe-8d6a-0a680690cf7c.png)


## ENLACE DEL VÍDEO

No aplica. 

## ELIMINACIÓN O CONSERVACIÓN DE LA RAMA

A la última persona en hacer la revisión, por tanto, la encargada de hacer el merge, se le solicita: 

- [x] Eliminar la rama al hacer el merge
- [ ] Conservar la rama al hacer el merge

## COMENTARIOS ADICIONALES

No aplica. 
